### PR TITLE
Add support for gleam >=0.32.0

### DIFF
--- a/src/gleam/bbmustache.gleam
+++ b/src/gleam/bbmustache.gleam
@@ -1,4 +1,4 @@
-import gleam/string_builder.{StringBuilder}
+import gleam/string_builder.{type StringBuilder}
 
 // Template compilation
 pub type Template


### PR DESCRIPTION
It is now a compile error to import a type without a `type` keyword. This change updates this package to work with gleam versions >=0.32.0