### PR TITLE
fix broken readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,14 @@ Gleam bindings to the [bbmustache][bbmustache] templating library.
 
 ```gleam
 import gleam/bbmustache.{string}
-import gleam/expect
+import gleeunit/should
 
 pub fn main() {
   let assert Ok(template) = bbmustache.compile("Hello, {{name}}!")
 
-  let rendered = bbmustache.render(template, [
-    string("name", "World"),
-  ])
+  let rendered = bbmustache.render(template, [#("name", string("World"))])
 
-  expect.equal(rendered, "Hello, World!")
+  should.equal(rendered, "Hello, World!")
 }
 ```
 


### PR DESCRIPTION
The example in the readme doesn't compile. This fixes it by using gleeunit and by using the correct arguments for bbmustache.string and bbmustache.render